### PR TITLE
User warned if OpenCV import fails

### DIFF
--- a/endocal/__init__.py
+++ b/endocal/__init__.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python
 
+try:
+    from cv2 import VideoCapture, imshow, waitKey,\
+        putText, FONT_HERSHEY_PLAIN, drawChessboardCorners
+except ImportError as e:
+    print('OpenCV does not seem to be installed on your system.')
+    print('See http://opencv.org for how to install it.')
+    print('The detailed error message was:')
+    print(e.message)
+    quit()
+
 from argparse import ArgumentParser
-from cv2 import VideoCapture, imshow, waitKey, putText, FONT_HERSHEY_PLAIN,\
-    drawChessboardCorners
 from numpy import zeros, uint8
 import pkg_resources
 from os.path import join

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='16.07.27rc5',
+    version='16.07.28rc1',
 
     description='A compact GUI application for optical distortion calibration of endoscopes',
     long_description=long_description,
@@ -79,9 +79,6 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=['PyYAML', 'numpy'],
-
-    # External dependencies not on PyPI
-    dependency_links=['http://opencv.org/'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='16.07.28rc1',
+    version='16.07.28rc4',
 
     description='A compact GUI application for optical distortion calibration of endoscopes',
     long_description=long_description,


### PR DESCRIPTION
I dug into the Python packaging docs, but couldn't find how to do it on installation. So for now I've added a warning when user tries to launch the application and OpenCV imports are not found.

**NB**: this version is not on PyPI yet, but already on the test server of PyPI. So you could test it by installing it from there: `pip install -i https://testpypi.python.org/pypi endocal==16.7.28rc4` You might need to `pip uninstall endocal` first.
